### PR TITLE
feat: Add commit history tree display

### DIFF
--- a/src/components/CommitTreeDisplay.tsx
+++ b/src/components/CommitTreeDisplay.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import type { GroupedCommits, CommitGroup } from '../types';
+import type { GitHubCommit } from '../services/githubService';
+
+interface CommitCardProps {
+  commit: GitHubCommit;
+}
+
+const CommitCard: React.FC<CommitCardProps> = ({ commit }) => {
+  const { message, author, date } = commit.commit;
+  const commitDate = new Date(date);
+
+  // Limiting message length for display
+  const shortMessage = message.split('\n')[0]; // Get first line
+  const displayMessage = shortMessage.length > 100 ? `${shortMessage.substring(0, 97)}...` : shortMessage;
+
+  return (
+    <div className="bg-slate-700 p-3 mb-3 rounded-lg shadow hover:shadow-md transition-shadow duration-200 ease-in-out">
+      <h4 className="text-sm font-semibold text-blue-300 mb-1 break-words" title={message}>
+        {displayMessage}
+      </h4>
+      <div className="text-xs text-slate-400">
+        <p><strong>Author:</strong> {author.name} ({author.email})</p>
+        <p><strong>Date:</strong> {commitDate.toLocaleString()}</p>
+        <a
+          href={commit.html_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-400 hover:text-blue-300 hover:underline text-xs mt-1 inline-block"
+        >
+          View on GitHub ({commit.sha.substring(0, 7)})
+        </a>
+      </div>
+    </div>
+  );
+};
+
+interface CommitGroupProps {
+  group: CommitGroup;
+}
+
+const CommitGroupDisplay: React.FC<CommitGroupProps> = ({ group }) => {
+  return (
+    <div className="mb-6 pl-4 border-l-2 border-slate-600">
+      <h3 className="text-xl font-semibold text-slate-200 mb-3 sticky top-0 bg-slate-800 py-2 z-10">{group.scope}</h3>
+      <div className="space-y-2">
+        {group.commits.map(commit => (
+          <CommitCard key={commit.sha} commit={commit} />
+        ))}
+      </div>
+      {group.commits.length === 0 && <p className="text-slate-400">No commits in this group.</p>}
+    </div>
+  );
+};
+
+interface CommitTreeDisplayProps {
+  groupedCommits: GroupedCommits | null;
+  repoUrl: string; // For context, like displaying the repo name
+}
+
+export const CommitTreeDisplay: React.FC<CommitTreeDisplayProps> = ({ groupedCommits, repoUrl }) => {
+  if (!groupedCommits) {
+    return null; // Or a loading/placeholder state if preferred
+  }
+
+  if (groupedCommits.length === 0) {
+    return (
+      <div className="mt-6 p-4 bg-slate-800 rounded-lg shadow">
+        <h2 className="text-2xl font-semibold text-slate-100 mb-4">Commit History</h2>
+        <p className="text-slate-400">No commit data to display. This could be due to an error, an empty repository, or no commits found for the selected branch.</p>
+      </div>
+    );
+  }
+
+  const repoName = repoUrl.split('/').slice(-2).join('/');
+
+
+  return (
+    <div className="mt-6 p-4 bg-slate-800/50 rounded-lg shadow-xl">
+      <h2 className="text-2xl font-semibold text-slate-100 mb-6">Commit History for <span className='text-teal-400'>{repoName}</span></h2>
+      <div className="relative"> {/* For potential sticky headers within groups */}
+        {groupedCommits.map(group => (
+          <CommitGroupDisplay key={group.scope} group={group} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/services/commitProcessorService.ts
+++ b/src/services/commitProcessorService.ts
@@ -1,0 +1,60 @@
+import type { GitHubCommit } from './githubService';
+import type { CommitGroup, GroupedCommits } from '../types';
+
+// Regex to find issue numbers like #123, fixes #123, closes #123, resolves #123
+// It captures the issue number.
+const ISSUE_REGEX = /(?:fixes|closes|resolves)\s+#(\d+)|#(\d+)/i;
+
+/**
+ * Groups commits by scope (e.g., "Issue #123" or "General Improvements").
+ * If a commit message refers to an issue number, it's grouped under that issue.
+ * Otherwise, it's grouped under "General Improvements".
+ *
+ * @param commits Array of GitHubCommit objects.
+ * @returns GroupedCommits array.
+ */
+export function groupCommitsByScope(commits: GitHubCommit[]): GroupedCommits {
+  if (!commits || commits.length === 0) {
+    return [];
+  }
+
+  const groups: Map<string, GitHubCommit[]> = new Map();
+
+  for (const commit of commits) {
+    const message = commit.commit.message;
+    const match = message.match(ISSUE_REGEX);
+
+    let scope = "General Improvements"; // Default scope
+
+    if (match) {
+      // match[1] is for "fixes #123", match[2] is for "#123"
+      const issueNumber = match[1] || match[2];
+      if (issueNumber) {
+        scope = `Issue #${issueNumber}`;
+      }
+    }
+
+    if (!groups.has(scope)) {
+      groups.set(scope, []);
+    }
+    groups.get(scope)!.push(commit);
+  }
+
+  // Convert map to array of CommitGroup
+  const result: GroupedCommits = [];
+  for (const [scope, scopeCommits] of groups.entries()) {
+    result.push({
+      scope,
+      commits: scopeCommits.sort((a, b) => new Date(b.commit.author.date).getTime() - new Date(a.commit.author.date).getTime()) // Sort commits by date, newest first
+    });
+  }
+
+  // Optional: Sort groups. For example, "General Improvements" last.
+  result.sort((a, b) => {
+    if (a.scope === "General Improvements") return 1;
+    if (b.scope === "General Improvements") return -1;
+    return a.scope.localeCompare(b.scope); // Sort other scopes alphabetically/numerically
+  });
+
+  return result;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,14 @@ export interface LanguageOption {
   value: string;
   label: string;
 }
+
+// Using the GitHubCommit interface from githubService
+// We might re-export it here or import it where needed.
+// For now, components/services can import it directly from githubService.
+
+export interface CommitGroup {
+  scope: string; // e.g., "Issue #123" or "General Improvements"
+  commits: import('./services/githubService').GitHubCommit[];
+}
+
+export type GroupedCommits = CommitGroup[];


### PR DESCRIPTION
- Fetches commits from GitHub repository.
- Processes commit messages to group by issue scope.
- Displays commits in a tree-like structure (grouped list) in a React card format.
- Integrates into the existing application flow, showing commit history below the code review panel.

New components:
- CommitTreeDisplay.tsx
- CommitCard.tsx (within CommitTreeDisplay)
- CommitGroupDisplay.tsx (within CommitTreeDisplay)

New services:
- commitProcessorService.ts (groups commits)

Modified services:
- githubService.ts (added fetchCommits, GitHubCommit interface)

Modified UI:
- App.tsx (integrated new feature, state management, and rendering)